### PR TITLE
Use omitzero for allowed mentions arrays

### DIFF
--- a/fluxer/allowed_mentions.go
+++ b/fluxer/allowed_mentions.go
@@ -6,9 +6,9 @@ import (
 
 // AllowedMentions are used for avoiding mentioning users in Message and Interaction
 type AllowedMentions struct {
-	Parse       []AllowedMentionType `json:"parse"`
-	Roles       []snowflake.ID       `json:"roles"`
-	Users       []snowflake.ID       `json:"users"`
+	Parse       []AllowedMentionType `json:"parse,omitzero"`
+	Roles       []snowflake.ID       `json:"roles,omitzero"`
+	Users       []snowflake.ID       `json:"users,omitzero"`
 	RepliedUser bool                 `json:"replied_user"`
 }
 


### PR DESCRIPTION
Fluxer does not allow null values here - and the semantics also differ between omitting it and an empty array unlike Discord (so omitempty cannot be used):

https://github.com/fluxerapp/fluxer/blob/b63628b4a2a8464db9d7fc15793df47da5752ef8/packages/api/src/channel/services/message/MessageMentionService.tsx#L149-L153